### PR TITLE
Speed up inference

### DIFF
--- a/pose_estimation/model/pe_model.py
+++ b/pose_estimation/model/pe_model.py
@@ -18,6 +18,7 @@
 import json
 import numpy as np
 import tensorflow as tf
+import cv2
 
 from .core import PoseEstimatorInterface
 from .utils.algorithm_connect_skelet import estimate_paf, merge_similar_skelets
@@ -121,46 +122,15 @@ class PEModel(PoseEstimatorInterface):
         Initialize tensors for prediction
 
         """
-        # Store (H, W) - final size of the prediction
-        self.upsample_size = tf.placeholder(dtype=tf.int32, shape=(2), name=PEModel.UPSAMPLE_SIZE)
 
-        # [N, W, H, NUM_KP]
-        main_paf = self.get_main_paf_tensor()
-
-        # [N, W, H, NUM_PAFS, 2]
-        shape_paf = main_paf.shape.as_list()
-        dynamic_shape = tf.shape(main_paf)
-        num_pafs = shape_paf[3]
-
-        for i in range(len(shape_paf)):
-            if shape_paf[i] is None:
-                shape_paf[i] = dynamic_shape[i]
-
-        # [N, W, H, NUM_PAFS * 2] --> [N, NEW_W, NEW_H, NUM_PAFS * 2]
-        main_paf = tf.reshape(main_paf, shape=shape_paf[:-2] + [-1])
-        self._resized_paf = tf.image.resize_area(
-            main_paf,
-            self.upsample_size,
-            align_corners=False,
-            name='upsample_paf'
+        self.input_smoothed_image = tf.placeholder(
+            shape=[1, None, None, 25],
+            dtype=tf.float32,
+            name='smoothed_input_image'
         )
-
-        # [N, NEW_W, NEW_H, NUM_PAFS * 2] --> [N, NEW_W, NEW_H, NUM_PAFS, 2]
-        new_shape = tf.stack(
-            [self.get_batch_size(), self.upsample_size[0], self.upsample_size[1], num_pafs, 2]
-        )
-        self._resized_paf = tf.reshape(self._resized_paf, shape=new_shape)
-
-        self._resized_heatmap = tf.image.resize_area(
-            self.get_main_heatmap_tensor(),
-            self.upsample_size,
-            align_corners=False,
-            name='upsample_heatmap'
-        )
-
         num_keypoints = self.get_main_heatmap_tensor().get_shape().as_list()[-1]
         self._smoother = Smoother(
-            {Smoother.DATA: self._resized_heatmap},
+            {Smoother.DATA: self.input_smoothed_image},
             25,
             3.0,
             num_keypoints
@@ -168,10 +138,10 @@ class PEModel(PoseEstimatorInterface):
 
         # Apply NMS (Non maximum suppression)
         # Apply max pool operation to heatmap
-        self._max_pooled_heatmap = tf.nn.max_pool(
+        max_pooled_heatmap = tf.nn.max_pool(
             self._smoother.get_output(),
             self._DEFAULT_KERNEL_MAX_POOL,
-            strides=[1,1,1,1],
+            strides=[1, 1, 1, 1],
             padding='SAME'
         )
         # Take only values that equal to heatmap from max pooling,
@@ -179,7 +149,7 @@ class PEModel(PoseEstimatorInterface):
         self._peaks = tf.where(
             tf.equal(
                 self._smoother.get_output(),
-                self._max_pooled_heatmap
+                max_pooled_heatmap
             ),
             self._smoother.get_output(),
             tf.zeros_like(self._smoother.get_output())
@@ -226,24 +196,46 @@ class PEModel(PoseEstimatorInterface):
             # Take `H`, `W` from input image
             resize_to = x[0].shape[:2]
 
-        batched_heatmap, batched_paf, batched_peaks = self._session.run(
-            [self._smoother.get_output(), self._resized_paf, self._peaks],
-            feed_dict={
-                self._input_data_tensors[0]: x,
-                self.upsample_size: resize_to
-            }
+        paf_prediction, heatmap_prediction = self._session.run(
+            [self.get_main_paf_tensor(), self.get_main_heatmap_tensor()],
+            feed_dict={self._input_data_tensors[0]: x}
+        )
+
+        # Process PAF
+        # [N, W, H, NUM_PAFS, 2]
+        shape_paf = paf_prediction.shape
+        N, num_pafs = shape_paf[0], shape_paf[3]
+
+        # [N, W, H, NUM_PAFS * 2] --> [N, NEW_W, NEW_H, NUM_PAFS * 2]
+        paf_prediction_reshaped = paf_prediction.reshape(*shape_paf[:-2], -1)
+        batched_paf = np.stack(
+            [
+                cv2.resize(paf_prediction_reshaped[i], (resize_to[1], resize_to[0]), interpolation=cv2.INTER_AREA)
+                for i in range(len(paf_prediction_reshaped))
+            ]
+        )
+        # Process HEATMAP
+        batched_heatmap = np.stack(
+            [
+                cv2.resize(heatmap_prediction[i], (resize_to[1], resize_to[0]), interpolation=cv2.INTER_AREA)
+                for i in range(len(heatmap_prediction))
+            ]
+        )
+        # Get peaks
+        batched_peaks = self._session.run(
+            self._peaks,
+            feed_dict={self.input_smoothed_image: batched_heatmap.astype(np.float32, copy=False)}
         )
 
         if using_estimate_alg:
 
             # Connect skeletons by applying two algorithms
             batched_humans = []
-            H, W = resize_to
 
             for i in range(len(batched_peaks)):
                 single_peaks = batched_peaks[i].astype(np.float32, copy=False)
                 single_heatmap = batched_heatmap[i].astype(np.float32, copy=False)
-                single_paff = batched_paf[i].reshape(H, W, -1).astype(np.float32, copy=False)
+                single_paff = batched_paf[i].astype(np.float32, copy=False)
 
                 # Estimate
                 humans_list = estimate_paf(single_peaks, single_heatmap, single_paff)
@@ -254,7 +246,9 @@ class PEModel(PoseEstimatorInterface):
 
             return batched_humans
         else:
-            return batched_peaks, batched_heatmap, batched_paf
+            # For paf
+            # [N, NEW_W, NEW_H, NUM_PAFS * 2] --> [N, NEW_W, NEW_H, NUM_PAFS, 2]
+            return batched_peaks, batched_heatmap, batched_paf.reshape(N, *resize_to, num_pafs, 2)
 
     def get_main_paf_tensor(self):
         return self._output_data_tensors[self._index_of_main_paf]

--- a/pose_estimation/model/pe_model.py
+++ b/pose_estimation/model/pe_model.py
@@ -122,13 +122,13 @@ class PEModel(PoseEstimatorInterface):
         Initialize tensors for prediction
 
         """
+        num_keypoints = self.get_main_heatmap_tensor().get_shape().as_list()[-1]
 
         self.input_smoothed_image = tf.placeholder(
-            shape=[1, None, None, 25],
+            shape=[1, None, None, num_keypoints],
             dtype=tf.float32,
             name='smoothed_input_image'
         )
-        num_keypoints = self.get_main_heatmap_tensor().get_shape().as_list()[-1]
         self._smoother = Smoother(
             {Smoother.DATA: self.input_smoothed_image},
             25,


### PR DESCRIPTION
Refactor predict method on PEModel.
Resize method in tensorFlow (tf.image.resize_area) is very SLOW operation compare to cv2.
All resize stuff calculated with cv2, smoothe (and calculation of peaks) calculated with tf.
As a result final inference time were speed up about x2-x3