### PR TITLE
Old paf speedup test

### DIFF
--- a/pose_estimation/model/pe_model.py
+++ b/pose_estimation/model/pe_model.py
@@ -122,13 +122,13 @@ class PEModel(PoseEstimatorInterface):
         Initialize tensors for prediction
 
         """
-
+        num_keypoints = self.get_main_heatmap_tensor().get_shape().as_list()[-1]
+        
         self.input_smoothed_image = tf.placeholder(
-            shape=[1, None, None, 25],
+            shape=[1, None, None, num_keypoints],
             dtype=tf.float32,
             name='smoothed_input_image'
         )
-        num_keypoints = self.get_main_heatmap_tensor().get_shape().as_list()[-1]
         self._smoother = Smoother(
             {Smoother.DATA: self.input_smoothed_image},
             25,


### PR DESCRIPTION
Refactor predict method on PEModel.
Resize method in tensorFlow (tf.image.resize_area) is very SLOW operation compare to cv2.
All resize stuff calculated with cv2, smoothe (and calculation of peaks) calculated with tf.
As a result final inference time were speed up about x2-x3